### PR TITLE
added quasi random points infill scan strategy

### DIFF
--- a/docs/scanning_strategies.md
+++ b/docs/scanning_strategies.md
@@ -41,6 +41,9 @@ The following scan strategies are supported:
 ### point_random
 no additional settings
 
+### point quasi random
+no additional settings
+
 ### point_ordered
 | Setting Key | Data Type | Description                                           | Example Value |
 |-------------|-----------|-------------------------------------------------------|---------------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "obpcreator"
-version = "0.0.11"
+version = "0.0.12"
 authors = [
     { name = "Anton Wiberg", email = "wiberg.anton@gmail.com" }
 ]


### PR DESCRIPTION
Added an option for a quasi random point distribution. It should yield more consistent builds and ensures that no two adjacent points are melted directly after one another.